### PR TITLE
Corrects impossibility to the user enter to realizes register

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user, except: [:new, :create]
   before_action :not_allow_to_enter_login, only: [:new, :create]
-  before_action :check_current_user
+  before_action :check_current_user, except: [:new, :create]
 
   # GET /users
   # GET /users.json


### PR DESCRIPTION
Adds a except to build before_action method only when the action is different of the register action.